### PR TITLE
fix top domains scrolling issue

### DIFF
--- a/page/index.html
+++ b/page/index.html
@@ -224,7 +224,7 @@
                             </p>
                             <div
                                 id="topDomainsOverview"
-                                class="space-y-2 max-h-80 overflow-y-auto"
+                                class="space-y-2"
                             ></div>
                         </div>
                     </div>


### PR DESCRIPTION
fixes https://github.com/publi0/mikrotik-dns/issues/5
you dont need overflow as the top 10 is smaller than list on left
also dont need max height as same thing its smaller than list on left