### PR TITLE
fix docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,6 @@ services:
     build: .
     ports:
       - "5354:5354/udp"
+      - "8080:8080/tcp"
     volumes:
-      - ./data:/app/data
-    networks:
-      - internal
-networks:
-  internal:
-    external: true
+      - ./data:/data


### PR DESCRIPTION
fixes https://github.com/publi0/mikrotik-dns/issues/4
adds missing http port
fixed wrong data folder
removed networks as not required
you can run this on a docker network without using host network or macvlan etc
